### PR TITLE
fix image type in help to png.

### DIFF
--- a/camera/camera.html
+++ b/camera/camera.html
@@ -25,7 +25,7 @@
         <li>Add the camera node to your flow</li>
         <li>Click the <code>button</code> capture an image from the webcam</li>
     </ol>
-    <p>The <code>jpg</code> image is sent as the <code>msg.payload</code> object</p>
+    <p>The <code>png</code> image is sent as the <code>msg.payload</code> object</p>
     <p>Supported browsers</p>
     <ul>
       <li>Chrome</li>


### PR DESCRIPTION
canvas.toBlob default format is png. I tested on Firefox 49.0.2 and Chrome 54.0.2840.99 m on Windows.