### PR TITLE
Correct output format of Camera node

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run the following command in the root directory of your Node-RED install:
 
 ### Camera
 
-The browser takes a picture with the default camera when the button next to the node is clicked. The node outputs it as a JPEG buffer.
+The browser takes a picture with the default camera when the button next to the node is clicked. The node outputs it as a PNG buffer.
 
 The `camera` node has a 2000ms delay to prevent slow camera driver startup causing an issue in some browsers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-browser-utils",
-  "version": "0.0.9",
+  "version": "0.0.8",
   "description": "A collection of Node-RED nodes for browser interaction",
   "dependencies": {
     "node-red-contrib-play-audio": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-browser-utils",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A collection of Node-RED nodes for browser interaction",
   "dependencies": {
     "node-red-contrib-play-audio": "^2.3.2",


### PR DESCRIPTION
Because Camera node outputs PNG buffer not JPEG, I modified the document.